### PR TITLE
Add tunable parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -233,6 +233,7 @@ class jenkins (
   $install_destination = $jenkins::params::install_destination,
   $install_precommand  = $jenkins::params::install_precommand,
   $install_postcommand = $jenkins::params::install_postcommand,
+  $install_warfile     = $jenkins::params::install_warfile,
   $url_check           = $jenkins::params::url_check,
   $url_pattern         = $jenkins::params::url_pattern,
   $my_class            = $jenkins::params::my_class,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -27,6 +27,7 @@ class jenkins::install inherits jenkins {
       puppi::netinstall { 'jenkins':
         url                 => $jenkins::install_source,
         destination_dir     => $jenkins::install_destination,
+        extracted_dir       => $jenkins::install_warfile,
         extract_command     => 'rsync',
         preextract_command  => $jenkins::install_precommand,
         postextract_command => $jenkins::install_postcommand,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,6 +49,11 @@ class jenkins::params {
 
   $install_postcommand = ''
 
+  $install_warfile = $::jenkins_install_warfile ? {
+    ''      => 'jenkins.war',                      # Default value
+    default => $::jenkins_install_warfile,
+  }
+
   $url_check           = ''
 
   $url_pattern         = 'OK'


### PR DESCRIPTION
for destination file name to pass into puppi::netinstall::extracted_dir.
Default value of this parameter fix bug when use install=source
and netinstall can not check if extraction successful.
