### PR TITLE
Runs apt-get update only once upon jenkins.ist change; provides idempote...

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -34,9 +34,10 @@ class jenkins::repository inherits jenkins {
         path    => '/bin:/usr/bin',
       }
       exec { 'aptget_update_jenkins':
-        command   => 'apt-get update',
-        subscribe => File['jenkins.list'],
-        path      => '/bin:/usr/bin',
+        command     => 'apt-get update',
+        refreshonly => true,
+        subscribe   => File['jenkins.list'],
+        path        => '/bin:/usr/bin',
       }
 
     }


### PR DESCRIPTION
On every puppet run Exec[aptget_update_jenkins] gets run which does not promote idempotency.

I prefer to run Exec[aptget_update_jenkins] only when jenkins.list actually has changed. In any other case this should be a noop. Therefore I added refreshonly to true for Exec[aptget_update_jenkins].
