### PR TITLE
Make the plugin manifest actually work, with limitiations (depends on Se...

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,10 +1,17 @@
 # jenkins::plugin based on https://github.com/rtyler/puppet-jenkins
-# To test and adapt
-define jenkins::plugin ( $version ='') {
+#
+# Plugin installation is only possible with $jenkins::install = package
+# due to the dependency on Service['jenkins'].
+#
+# TODO: Investigate usage of jenkins-cli to mitigate this limitation.
+define jenkins::plugin ($version='') {
 
   include jenkins::params
 
-  $plugin            = "${name}.hpi"
+  if (!defined(Service['jenkins'])) {
+    fail('Plugin installation not possible without a running jenkins installed by package.')
+  }
+
   $plugin_parent_dir = '/var/lib/jenkins'
   $plugin_dir        = '/var/lib/jenkins/plugins'
 
@@ -15,12 +22,36 @@ define jenkins::plugin ( $version ='') {
     $base_url = 'http://updates.jenkins-ci.org/latest/'
   }
 
+  if (!defined(File[$plugin_dir])) {
+    file { [ $plugin_parent_dir, $plugin_dir ]:
+      ensure  => directory,
+      owner   => 'jenkins',
+      mode    => '0644',
+      require => User['jenkins'],
+    }
+
+    File[$plugin_parent_dir] {
+      group => 'adm',
+    }
+
+    File[$plugin_dir] {
+      group => 'nogroup',
+    }
+  }
+
+  if (!defined(User['jenkins'])) {
+    user { 'jenkins':
+      ensure => present,
+    }
+  }
+
   exec { "download-jenkins-${name}" :
-      command  => "wget --no-check-certificate ${base_url}${plugin}",
-      cwd      => $plugin_dir,
-      require  => File[$plugin_dir],
-      path     => [ '/usr/bin', '/usr/sbin' ],
-      user     => 'jenkins',
-      unless   => "test -f ${plugin_dir}/${plugin}";
+    command => "wget --no-check-certificate ${base_url}${name}.hpi",
+    cwd     => $plugin_dir,
+    require => File[$plugin_dir],
+    path    => [ '/usr/bin', '/usr/sbin' ],
+    user    => 'jenkins',
+    unless  => "test -f ${plugin_dir}/${name}.hpi || test -f ${plugin_dir}/${name}.jpi",
+    notify  => Service['jenkins'],
   }
 }


### PR DESCRIPTION
The plugin manifest in its current form didn't work for as you stated in the comment. Not knowing to what you would like to adopt it I enhanced it to serve at least my current scenario. Having played with jenkins-cli I returned to wget. So, the plugin now:
- installs the latest or a specific version of a plugin
- unless its already installed
- general purpose is initial provisioning of a jenkins server
- fails actively if Service['jenkins'] is not defined
- handles hpi vs. jpi situation (when jenkins webapp was used to update/install)

Known limitations:
- does only work with jenkins::params::install = package due to 
  - dependency on /var/lib/jenkins/plugins (in tomcat the plugin_dir seems to elsewhere)
  - dependency on Service['jenkins']
- does not compare to be installed version of a plugin with already installed version => not autoupdates of plugins

For me the current state is useful in daily business, plugin comparison and autoupdate (to specific or latest version ) of plugins would be nice to have, but more work.

Tested with vagrant/Ubuntu 12.04.1 LTS only.
